### PR TITLE
Prepare for prow - add unit-tests to Makefile.prow

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -5,3 +5,7 @@
 .PHONY: build
 build:
 	CGO_ENABLED=0 GOGC=25 go build -o $(BINDIR)/search-collector ./
+
+.PHONY: unit-test
+unit-test:
+	DEPLOYED_IN_HUB=true go test ./... -v -coverprofile cover.out


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9582

### Description of changes
- Add unit-test target to Makefile.prow

