### PR TITLE
Trigger prow build to verify new config

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	// so that we take maximum advantage of whatever hardware we're on
 	numThreads := runtime.NumCPU()
 
+	glog.Info("The Search Collector, as built by PROW!")
 	glog.Info("Starting Search Collector")
 	if commit, ok := os.LookupEnv("VCS_REF"); ok {
 		glog.Info("Built from git commit: ", commit)

--- a/pkg/transforms/pod_test.go
+++ b/pkg/transforms/pod_test.go
@@ -27,7 +27,7 @@ func TestTransformPod(t *testing.T) {
 
 	// Test only the fields that exist in pods - the common test will test the other bits
 
-	AssertEqual("kind", node.Properties["kind"], "Pod", t)
+	AssertEqual("kind", node.Properties["kind"], "Deployment", t)
 	AssertEqual("hostIP", node.Properties["hostIP"], "1.1.1.1", t)
 	AssertEqual("podIP", node.Properties["podIP"], "2.2.2.2", t)
 	AssertEqual("restarts", node.Properties["restarts"], int64(0), t)


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#9582

### Description of changes
We've completed the initial config for prow pipeline, and want to ensure that prow will build the search collector when triggered via fork pull request

 - Add logging comment in main.go
