### PR TITLE
remove deprecated selfLink

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -69,7 +69,6 @@ func createNodeEvents() []tr.NodeEvent {
 	p.Name = "testpod"
 	p.Kind = "Pod"
 	p.Namespace = "default"
-	p.SelfLink = "/api/v1/namespaces/default/pods/testpod"
 	p.UID = "5678"
 	podNode := tr.PodResourceBuilder(&p).BuildNode()
 	podNode.Metadata["OwnerUID"] = "local-cluster/1234"

--- a/pkg/transforms/common.go
+++ b/pkg/transforms/common.go
@@ -33,7 +33,6 @@ func commonProperties(resource machineryV1.Object) map[string]interface{} {
 	ret := make(map[string]interface{})
 
 	ret["name"] = resource.GetName()
-	ret["selfLink"] = resource.GetSelfLink()
 	ret["created"] = resource.GetCreationTimestamp().UTC().Format(time.RFC3339)
 	ret["_clusterNamespace"] = config.Cfg.ClusterNamespace
 	if config.Cfg.DeployedInHub {

--- a/pkg/transforms/common_test.go
+++ b/pkg/transforms/common_test.go
@@ -29,7 +29,6 @@ func CreateGenericResource() machineryV1.Object {
 	p.APIVersion = "v1"
 	p.Name = "testpod"
 	p.Namespace = "default"
-	p.SelfLink = "/api/v1/namespaces/default/pods/testpod"
 	p.UID = "00aa0000-00aa-00a0-a000-00000a00a0a0"
 	p.CreationTimestamp = timestamp
 	p.Labels = labels
@@ -46,7 +45,6 @@ func TestCommonProperties(t *testing.T) {
 	// Test all the fields.
 	AssertEqual("name", cp["name"], interface{}("testpod"), t)
 	AssertEqual("namespace", cp["namespace"], interface{}("default"), t)
-	AssertEqual("selfLink", cp["selfLink"], interface{}("/api/v1/namespaces/default/pods/testpod"), t)
 	AssertEqual("created", cp["created"], interface{}(timeString), t)
 
 	noLabels := true

--- a/pkg/transforms/genericresource.go
+++ b/pkg/transforms/genericresource.go
@@ -52,7 +52,6 @@ func unstructuredProperties(r *unstructured.Unstructured) map[string]interface{}
 
 	ret["kind"] = r.GetKind()
 	ret["name"] = r.GetName()
-	ret["selfLink"] = r.GetSelfLink()
 	ret["created"] = r.GetCreationTimestamp().UTC().Format(time.RFC3339)
 	ret["_clusterNamespace"] = config.Cfg.ClusterNamespace
 	if config.Cfg.DeployedInHub {


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#10696

### Description of changes
- Removes selfLink.  It was removed in K8s 1.20

