### PR TITLE
Add policy report result field to redis

### DIFF
--- a/pkg/transforms/policyreport.go
+++ b/pkg/transforms/policyreport.go
@@ -18,15 +18,15 @@ type PolicyReport struct {
 
 // ReportResults rule violation results
 type ReportResults struct {
-	Policy      string     `json:"policy"`
-	Description string     `json:"message"`
-	Category    string     `json:"category"`
-	Result      string     `json:"result"`
-	Properties  ReportData `json:"properties"`
+	Policy      string           `json:"policy"`
+	Message     string           `json:"message"`
+	Category    string           `json:"category"`
+	Result      string           `json:"result"`
+	Properties  ReportProperties `json:"properties"`
 }
 
-// ReportData rule violation data
-type ReportData struct {
+// ReportProperties rule violation data
+type ReportProperties struct {
 	Created    string `json:"created_at"`
 	Details    string `json:"details"`
 	TotalRisk  string `json:"total_risk"`
@@ -49,9 +49,10 @@ func PolicyReportResourceBuilder(pr *PolicyReport) *PolicyReportResource {
 	node.Properties["apigroup"] = gvk.Group
 
 	// Extract the properties specific to this type
-	node.Properties["message"] = string(pr.Results[0].Description)
+	node.Properties["message"] = string(pr.Results[0].Message)
 	node.Properties["category"] = strings.Split(pr.Results[0].Category, ",")
 	node.Properties["risk"] = string(pr.Results[0].Properties.TotalRisk)
+	node.Properties["result"] = string(pr.Results[0].Result)
 
 	return &PolicyReportResource{node: node}
 }

--- a/pkg/transforms/policyreport_test.go
+++ b/pkg/transforms/policyreport_test.go
@@ -16,6 +16,7 @@ func TestTransformPolicyReport(t *testing.T) {
 	AssertEqual("message", node.Properties["message"], "policyreport testing risk 1", t)
 	AssertDeepEqual("category", node.Properties["category"], []string{"category", "category1", "category2"}, t)
 	AssertEqual("risk", node.Properties["risk"], "1", t)
+	AssertEqual("result", node.Properties["result"], "error", t)
 }
 
 func TestPolicyReportBuildEdges(t *testing.T) {

--- a/test-data/policyreport.json
+++ b/test-data/policyreport.json
@@ -17,7 +17,7 @@
             },
             "message": "policyreport testing risk 1",
             "policy": "policyreport testing risk 1 policy",
-            "status": "policyreport testing risk 1 status"
+            "result": "error"
         }
     ]
 }


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

### Description of changes
- Adding results field ("error" or "skip") to redis for PolicyReports

