### PR TITLE
Add Argo app status to search collector

### DIFF
--- a/pkg/transforms/argoapplication.go
+++ b/pkg/transforms/argoapplication.go
@@ -14,7 +14,8 @@ type ArgoApplicationResource struct {
 type ArgoApplication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
-	Spec              ArgoApplicationSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+	Spec              ArgoApplicationSpec   `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+	Status            ArgoApplicationStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
 }
 
 type ArgoApplicationSpec struct {
@@ -35,6 +36,14 @@ type ArgoApplicationDestination struct {
 	Name      string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 }
 
+type ArgoApplicationStatus struct {
+	Health ArgoApplicationHealth `json:"health" protobuf:"bytes,1,opt,name=health"`
+}
+
+type ArgoApplicationHealth struct {
+	Status string `json:"status" protobuf:"bytes,1,opt,name=status"`
+}
+
 // ArgoApplicationResourceBuilder ...
 func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource {
 	node := transformCommon(a)
@@ -52,6 +61,9 @@ func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource
 	node.Properties["chart"] = a.Spec.Source.Chart
 	node.Properties["repoURL"] = a.Spec.Source.RepoURL
 	node.Properties["targetRevision"] = a.Spec.Source.TargetRevision
+
+	// Status properties
+	node.Properties["status"] = a.Status.Health.Status
 
 	return &ArgoApplicationResource{node: node}
 }

--- a/pkg/transforms/argoapplication_test.go
+++ b/pkg/transforms/argoapplication_test.go
@@ -20,4 +20,5 @@ func TestTransformArgoApplication(t *testing.T) {
 	AssertEqual("chart", node.Properties["chart"], "hello-chart", t)
 	AssertEqual("repoURL", node.Properties["repoURL"], "https://github.com/fxiang1/app-samples", t)
 	AssertEqual("targetRevision", node.Properties["targetRevision"], "HEAD", t)
+	AssertEqual("status", node.Properties["status"], "Healthy", t)
 }

--- a/test-data/argoapplication.json
+++ b/test-data/argoapplication.json
@@ -24,5 +24,10 @@
               "selfHeal": true
           }
       }
+  },
+  "status": {
+      "health": {
+          "status": "Healthy"
+      }
   }
 }


### PR DESCRIPTION
**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/11353

### Description of changes
- Added the Argo app status to the search collector

The search query now return the status of the Argo app:
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/38960034/114924600-2ac7f900-9dfc-11eb-9477-9d3716d4da6a.png">
