### PR TITLE
Add cluster scope of policyreport resources

### DIFF
--- a/pkg/transforms/policyreport.go
+++ b/pkg/transforms/policyreport.go
@@ -7,13 +7,15 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // PolicyReport report
 type PolicyReport struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Results           []ReportResults `json:"results"`
+	metav1.TypeMeta                          `json:",inline"`
+	metav1.ObjectMeta                        `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Results           []ReportResults        `json:"results"`
+	Scope             corev1.ObjectReference `json:"scope"`
 }
 
 // ReportResults rule violation results
@@ -65,6 +67,8 @@ func PolicyReportResourceBuilder(pr *PolicyReport) *PolicyReportResource {
 	}
 	node.Properties["insightPolicies"] = policies
 	node.Properties["category"] = categories
+	// extract the cluster scope from the PolicyReport resource
+	node.Properties["scope"] = string(pr.Scope.Name)
 	return &PolicyReportResource{node: node}
 }
 

--- a/pkg/transforms/policyreport_test.go
+++ b/pkg/transforms/policyreport_test.go
@@ -17,7 +17,7 @@ func TestTransformPolicyReport(t *testing.T) {
 	AssertDeepEqual("insightPolicies", node.Properties["insightPolicies"], []string{"policyreport testing risk 1 policy", "policyreport testing risk 2 policy"}, t)
 	AssertDeepEqual("numInsightPolicies", node.Properties["numInsightPolicies"], 2, t)
 
-	AssertDeepEqual("scope", node.Properties["scope"], "test-clsuter", t)
+	AssertDeepEqual("scope", node.Properties["scope"], "test-cluster", t)
 }
 
 func TestPolicyReportBuildEdges(t *testing.T) {

--- a/pkg/transforms/policyreport_test.go
+++ b/pkg/transforms/policyreport_test.go
@@ -16,6 +16,8 @@ func TestTransformPolicyReport(t *testing.T) {
 	AssertDeepEqual("category Length", len(node.Properties["category"].([]string)), 5, t)
 	AssertDeepEqual("insightPolicies", node.Properties["insightPolicies"], []string{"policyreport testing risk 1 policy", "policyreport testing risk 2 policy"}, t)
 	AssertDeepEqual("numInsightPolicies", node.Properties["numInsightPolicies"], 2, t)
+
+	AssertDeepEqual("scope", node.Properties["scope"], "test-clsuter", t)
 }
 
 func TestPolicyReportBuildEdges(t *testing.T) {

--- a/test-data/policyreport.json
+++ b/test-data/policyreport.json
@@ -32,5 +32,10 @@
             "policy": "policyreport testing risk 2 policy",
             "result": "error"
         }
-    ]
+    ],
+    "scope": {
+        "kind": "cluster",
+        "name": "test-cluster",
+        "namespace": "test-cluster"
+    }
 }


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

https://github.com/open-cluster-management/backlog/issues/12669

### Description of changes
- index the cluster scope of policyreport resources
