### PR TITLE
Default Argo targetRevision to HEAD

### DIFF
--- a/pkg/transforms/argoapplication.go
+++ b/pkg/transforms/argoapplication.go
@@ -73,6 +73,9 @@ func ArgoApplicationResourceBuilder(a *ArgoApplication) *ArgoApplicationResource
 	node.Properties["chart"] = a.Spec.Source.Chart
 	node.Properties["repoURL"] = a.Spec.Source.RepoURL
 	node.Properties["targetRevision"] = a.Spec.Source.TargetRevision
+	if a.Spec.Source.TargetRevision == "" {
+		node.Properties["targetRevision"] = "HEAD"
+	}
 
 	// Status properties
 	node.Properties["status"] = a.Status.Health.Status


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/13638

### Description of changes

- Check if targetRevision is empty and default to `HEAD`