### PR TITLE
Handle when managed cluster does not support lease kind

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,11 +62,13 @@ func main() {
 
 	if !config.Cfg.DeployedInHub {
 		leaseReconciler := lease.LeaseReconciler{
-			KubeClient:           config.GetKubeClient(),
+			HubKubeClient:        config.GetKubeClient(config.Cfg.AggregatorConfig),
+			KubeClient:           config.GetKubeClient(config.GetKubeConfig()),
 			LeaseName:            AddonName,
+			ClusterName:          config.Cfg.ClusterName,
 			LeaseDurationSeconds: int32(LeaseDurationSeconds),
 		}
-		glog.Info("Create/Update lease for search on managed cluster")
+		glog.Info("Create/Update lease for search")
 		go wait.Forever(leaseReconciler.Reconcile, time.Duration(leaseReconciler.LeaseDurationSeconds)*time.Second)
 	}
 

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -70,7 +70,7 @@ func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
 			glog.Fatal("Cannot Construct Kube Client from Config: ", err)
 		}
 	} else {
-	  glog.Error("Cannot Construct Kube Client as input Config is nil")
+		glog.Error("Cannot Construct Kube Client as input Config is nil")
 	}
 	return kubeClient
 }

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -24,7 +24,7 @@ func GetDynamicClient() dynamic.Interface {
 	if dynamicClient != nil {
 		return dynamicClient
 	}
-	newDynamicClient, err := dynamic.NewForConfig(getKubeConfig())
+	newDynamicClient, err := dynamic.NewForConfig(GetKubeConfig())
 	if err != nil {
 		glog.Fatal("Cannot Construct Dynamic Client ", err)
 	}
@@ -33,7 +33,7 @@ func GetDynamicClient() dynamic.Interface {
 	return dynamicClient
 }
 
-func getKubeConfig() *rest.Config {
+func GetKubeConfig() *rest.Config {
 	var clientConfig *rest.Config
 	var clientConfigError error
 
@@ -54,17 +54,22 @@ func getKubeConfig() *rest.Config {
 
 // Get kubernetes client for discovering resource types.
 func GetDiscoveryClient() *discovery.DiscoveryClient {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(getKubeConfig())
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(GetKubeConfig())
 	if err != nil {
 		glog.Fatal("Cannot Construct Discovery Client From Config: ", err)
 	}
 	return discoveryClient
 }
 
-func GetKubeClient() *kubernetes.Clientset {
-	kubeClient, err := kubernetes.NewForConfig(getKubeConfig())
-	if err != nil {
-		glog.Fatal("Cannot Construct Kube Client from Config: ", err)
+func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
+	var kubeClient *kubernetes.Clientset
+	var err error
+	if config != nil {
+		kubeClient, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			glog.Fatal("Cannot Construct Kube Client from Config: ", err)
+		}
 	}
+	glog.Error("Cannot Construct Kube Client as input Config is nil")
 	return kubeClient
 }

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -69,7 +69,8 @@ func GetKubeClient(config *rest.Config) *kubernetes.Clientset {
 		if err != nil {
 			glog.Fatal("Cannot Construct Kube Client from Config: ", err)
 		}
+	} else {
+	  glog.Error("Cannot Construct Kube Client as input Config is nil")
 	}
-	glog.Error("Cannot Construct Kube Client as input Config is nil")
 	return kubeClient
 }

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -33,7 +33,7 @@ func (r *LeaseReconciler) Reconcile() {
 		glog.Errorf("Failed to update lease %s/%s: %v on managed cluster", r.LeaseName, r.componentNamespace, err)
 
 		// Try to create or update the lease on in the managed cluster's namespace on the hub cluster.
-		if r.HubKubeClient != nil {
+		if errors.IsNotFound(err) && r.HubKubeClient != nil {
 			glog.Errorf("Trying to update lease on the hub")
 
 			if err := r.updateLease(r.ClusterName, r.HubKubeClient); err != nil {


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#13558

### Description of changes
Create lease on remote cluster namespace on HUB if lease object is not available on the managed cluster (OCP 311)
