### PR TITLE
PR to trigger build, there was a glitch after #138

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ env:
     - COMPONENT_E2E_TEST_COMMAND=${TRAVIS_BUILD_DIR}/build/run-e2e-tests.sh
 
     - DEPLOYED_IN_HUB=true # For sonar
-    - GO111MODULE=on
 
 cache:
   directories:


### PR DESCRIPTION
**Related Issue:**  N/A

### Description of changes
- Go modules is on by default in 1.16
