### PR TITLE
Use the most current kube client connection for lease

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	if !config.Cfg.DeployedInHub {
 		leaseReconciler := lease.LeaseReconciler{
 			HubKubeClient:        config.GetKubeClient(config.Cfg.AggregatorConfig),
-			KubeClient:           config.GetKubeClient(config.GetKubeConfig()),
+			LocalKubeClient:      config.GetKubeClient(config.GetKubeConfig()),
 			LeaseName:            AddonName,
 			ClusterName:          config.Cfg.ClusterName,
 			LeaseDurationSeconds: int32(LeaseDurationSeconds),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ func init() {
 }
 
 func InitConfig() {
+	glog.Info("Loading config from environment.")
 	// Load default config from ./config.json.
 	// These can be overridden in the next step if environment variables are set.
 	if _, err := os.Stat(filepath.Join(".", "config.json")); !os.IsNotExist(err) {
@@ -155,7 +156,6 @@ func setDefault(field *string, env, defaultVal string) {
 	}
 }
 
-// TODO: Combine with function above.
 func setDefaultInt(field *int, env string, defaultVal int) {
 	if val := os.Getenv(env); val != "" {
 		glog.Infof("Using %s from environment: %s", env, val)

--- a/pkg/config/kubeClient.go
+++ b/pkg/config/kubeClient.go
@@ -38,10 +38,10 @@ func GetKubeConfig() *rest.Config {
 	var clientConfigError error
 
 	if Cfg.KubeConfig != "" {
-		glog.Infof("Creating k8s client using path: %s", Cfg.KubeConfig)
+		glog.Infof("Creating k8s client using KubeConfig at: %s", Cfg.KubeConfig)
 		clientConfig, clientConfigError = clientcmd.BuildConfigFromFlags("", Cfg.KubeConfig)
 	} else {
-		glog.Info("Creating k8s client using InClusterlientConfig()")
+		glog.V(2).Info("Creating k8s client using InClusterClientConfig()")
 		clientConfig, clientConfigError = rest.InClusterConfig()
 	}
 

--- a/pkg/lease/lease_test.go
+++ b/pkg/lease/lease_test.go
@@ -18,7 +18,7 @@ func TestCreateLeaseAddon(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	leaseReconciler := LeaseReconciler{
-		KubeClient:           client,
+		LocalKubeClient:      client,
 		LeaseName:            AddonName,
 		LeaseDurationSeconds: int32(LeaseDurationSeconds),
 	}
@@ -34,7 +34,7 @@ func TestUpdateLeaseAddon(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	leaseReconciler := LeaseReconciler{
-		KubeClient:           client,
+		LocalKubeClient:      client,
 		LeaseName:            AddonName,
 		LeaseDurationSeconds: int32(LeaseDurationSeconds),
 	}


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#17342
open-cluster-management/backlog#17789

### Description of changes

- Update the lease code to use the most current hub kube client every time the lease is renewed.
- Reload config after any lease errors.
- Reload config after any send error.